### PR TITLE
Exclude build directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+exclude =
+    build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.egg-info/
 .coverage
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+exclude = [
+    'build/',
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,5 @@ author_email = dickinsm@gmail.com
 [options]
 packages = find:
 
-[flake8]
-max-line-length = 88
-
 [isort]
 profile = black


### PR DESCRIPTION
Exclude the top-level `build` directory that's created by the `setuptools` installation in the various tools that might otherwise be confused by it.