### PR TITLE
Remove gratuitous use of walruses

### DIFF
--- a/rounder/format.py
+++ b/rounder/format.py
@@ -182,7 +182,8 @@ class FormatSpecification:
 
         kwargs = {}
 
-        if (round_type := match["type"]) == "f":
+        round_type = match["type"]
+        if round_type == "f":
             places = int(match["precision"])
             kwargs.update(
                 places=places,
@@ -194,10 +195,12 @@ class FormatSpecification:
         else:
             raise ValueError("Unhandled round type")
 
-        if (mode_code := match["mode"]) is not None:
+        mode_code = match["mode"]
+        if mode_code is not None:
             kwargs.update(rounding_mode=_MODE_FORMAT_CODES[mode_code])
 
-        if (sign := match["sign"]) == "+" or sign == " ":
+        sign = match["sign"]
+        if sign == "+" or sign == " ":
             kwargs.update(
                 positive_sign=sign,
                 positive_zero_sign=sign,


### PR DESCRIPTION
We don't need the walruses here, and they prevent the use of this code on Python 3.7. (We might want to drop support for Python 3.7 at some point, but we'd need a more compelling reason than just being able to use walruses.)