### PR TITLE
Work around mypy error on Python 3.7

### DIFF
--- a/rounder/format.py
+++ b/rounder/format.py
@@ -4,6 +4,7 @@ Formatting functionality.
 
 import dataclasses
 import re
+import sys
 import typing
 
 from rounder.core import Rounded
@@ -56,10 +57,10 @@ _MODE_FORMAT_CODES = {
 
 # Provide compatibility for Python versions older than 3.10, which don't support
 # kw_only.
-try:
-    frozen_dataclass = dataclasses.dataclass(frozen=True, kw_only=True)
-except TypeError:
+if sys.version_info < (3, 10):
     frozen_dataclass = dataclasses.dataclass(frozen=True)
+else:
+    frozen_dataclass = dataclasses.dataclass(frozen=True, kw_only=True)
 
 
 #: Class describing a format specification.


### PR DESCRIPTION
mypy doesn't understand the `try` / `except` formulation that we use below, so switch explicitly on Python version instead.