### PR TITLE
Quarters to tenths

### DIFF
--- a/src/rounder/decimal_overloads.py
+++ b/src/rounder/decimal_overloads.py
@@ -1,7 +1,7 @@
+import dataclasses
 import decimal
-from typing import cast
 
-from rounder.generics import decade, is_finite, is_zero, to_quarters, to_type_of
+from rounder.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounder.intermediate import IntermediateForm
 
 
@@ -22,29 +22,19 @@ def _(x: decimal.Decimal) -> bool:
     return x.is_zero()
 
 
-@to_quarters.register
-def _(x: decimal.Decimal, exponent: int = 0) -> IntermediateForm:
+@preround.register
+def _(x: decimal.Decimal, exponent: int) -> IntermediateForm:
     if not x.is_finite():
         raise ValueError("Input must be finite")
 
     sign, digit_tuple, x_exponent = x.as_tuple()
-    significand = int("".join(map(str, digit_tuple)))
-
-    scale = x_exponent - exponent + 1
-    if scale >= 0:
-        numerator, denominator = cast(int, 10**scale) * significand, 1
-    else:
-        numerator, denominator = significand, cast(int, 10**-scale)
-
-    tenths, inexact = divmod(numerator, denominator)
-    if tenths % 5 == 0 and inexact:
-        tenths += 1
-
-    return IntermediateForm(
-        sign=sign == 1,
-        significand=tenths,
-        exponent=exponent - 1,
+    rounded = IntermediateForm.from_signed_fraction(
+        sign=bool(sign),
+        numerator=int("".join(map(str, digit_tuple))),
+        denominator=1,
+        exponent=exponent - x_exponent,
     )
+    return dataclasses.replace(rounded, exponent=exponent)
 
 
 @decade.register

--- a/src/rounder/decimal_overloads.py
+++ b/src/rounder/decimal_overloads.py
@@ -30,19 +30,20 @@ def _(x: decimal.Decimal, exponent: int = 0) -> IntermediateForm:
     sign, digit_tuple, x_exponent = x.as_tuple()
     significand = int("".join(map(str, digit_tuple)))
 
-    scale = x_exponent - exponent
+    scale = x_exponent - exponent + 1
     if scale >= 0:
         numerator, denominator = cast(int, 10**scale) * significand, 1
     else:
         numerator, denominator = significand, cast(int, 10**-scale)
 
-    quarters, inexact = divmod(4 * numerator, denominator)
-    whole, part = divmod(quarters | bool(inexact), 4)
+    tenths, inexact = divmod(numerator, denominator)
+    if tenths % 5 == 0 and inexact:
+        tenths += 1
+
     return IntermediateForm(
         sign=sign == 1,
-        significand=whole,
-        quarters=part,
-        exponent=exponent,
+        significand=tenths,
+        exponent=exponent - 1,
     )
 
 

--- a/src/rounder/float_overloads.py
+++ b/src/rounder/float_overloads.py
@@ -3,7 +3,7 @@ import math
 import struct
 from typing import cast
 
-from rounder.generics import decade, is_finite, is_zero, to_quarters, to_type_of
+from rounder.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounder.intermediate import IntermediateForm
 
 #: Useful constants
@@ -720,15 +720,16 @@ def _(x: float) -> bool:
     return x == 0.0
 
 
-@to_quarters.register
-def _(x: float, exponent: int = 0) -> IntermediateForm:
+@preround.register
+def _(x: float, exponent: int) -> IntermediateForm:
     if not math.isfinite(x):
         raise ValueError("Input must be finite")
 
-    n, d = abs(x).as_integer_ratio()
+    sign = math.copysign(1.0, x) < 0.0
+    numerator, denominator = abs(x).as_integer_ratio()
     return IntermediateForm.from_signed_fraction(
-        sign=math.copysign(1.0, x) < 0.0,
-        numerator=n,
-        denominator=d,
+        sign=sign,
+        numerator=numerator,
+        denominator=denominator,
         exponent=exponent,
     )

--- a/src/rounder/format.py
+++ b/src/rounder/format.py
@@ -6,7 +6,7 @@ import dataclasses
 import re
 from typing import Any, Dict, Optional
 
-from rounder.generics import decade, is_zero, to_quarters
+from rounder.generics import decade, is_zero, preround
 from rounder.intermediate import IntermediateForm
 from rounder.modes import (
     TIES_TO_AWAY,
@@ -244,13 +244,13 @@ def format(value: Any, pattern: str) -> str:
 
         exponent = max(bounds)
 
-    quarters = to_quarters(value, exponent)
-    rounded = format_specification.rounding_mode.round(quarters)
+    prerounded = preround(value, exponent - 1)
+    rounded = format_specification.rounding_mode.round(prerounded)
     if format_specification.figures is not None:
 
         # Adjust if necessary.
         if len(str(rounded.significand)) == format_specification.figures + 1:
-            rounded = rounded.nudge()
+            rounded = rounded.to_zero()
 
     # Step 2: convert to string. Only supporting e and f-presentation formats right now.
     return format_specification.format(rounded)

--- a/src/rounder/fraction_overloads.py
+++ b/src/rounder/fraction_overloads.py
@@ -1,7 +1,7 @@
 import fractions
 from typing import cast
 
-from rounder.generics import decade, is_finite, is_zero, to_quarters, to_type_of
+from rounder.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounder.intermediate import IntermediateForm
 
 
@@ -40,7 +40,7 @@ def _(x: fractions.Fraction) -> bool:
     return x == 0
 
 
-@to_quarters.register
+@preround.register
 def _(x: fractions.Fraction, exponent: int) -> IntermediateForm:
     return IntermediateForm.from_signed_fraction(
         sign=x < 0,

--- a/src/rounder/generics.py
+++ b/src/rounder/generics.py
@@ -44,11 +44,11 @@ def is_zero(x: Any) -> bool:
 
 
 @functools.singledispatch
-def to_quarters(x: Any, exponent: int) -> IntermediateForm:
+def preround(x: Any, exponent: int) -> IntermediateForm:
     """
     Pre-rounding step for value x.
 
-    Rounds the number x / 10**exponent to the nearest quarter, using the
-    round-to-odd rounding mode. Returns the number of quarters.
+    Rounds x to the nearest integer multiple of 10**exponent, using the
+    round-for-reround rounding mode.
     """
     raise NotImplementedError(f"No overload available for type {type(x)}")

--- a/src/rounder/int_overloads.py
+++ b/src/rounder/int_overloads.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from rounder.generics import decade, is_finite, is_zero, to_quarters, to_type_of
+from rounder.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounder.intermediate import IntermediateForm
 
 
@@ -34,7 +34,7 @@ def _(x: int) -> bool:
     return x == 0
 
 
-@to_quarters.register
+@preround.register
 def _(x: int, exponent: int) -> IntermediateForm:
     return IntermediateForm.from_signed_fraction(
         sign=x < 0,

--- a/src/rounder/intermediate.py
+++ b/src/rounder/intermediate.py
@@ -2,11 +2,11 @@
 Representations of intermediate values.
 """
 
-import dataclasses
+from dataclasses import dataclass, replace
 from typing import cast
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class IntermediateForm:
     """
     Intermediate value for rounding and formatting operations.
@@ -17,7 +17,7 @@ class IntermediateForm:
     The value represented is (-1)**sign * significand * 10**exponent.
     """
 
-    # True for negative, False for positive.
+    # True for negative, False for positive
     sign: bool
 
     # Significand
@@ -28,66 +28,37 @@ class IntermediateForm:
 
     @classmethod
     def from_signed_fraction(
-        cls, sign: bool, numerator: int, denominator: int, exponent: int
+        cls, *, sign: bool, numerator: int, denominator: int, exponent: int
     ) -> "IntermediateForm":
         """
-        Create from a quotient of the form ±(n/d).
+        Create from a quotient of the form ±(n/d) with the target exponent, using
+        round-for-reround.
         """
-        if exponent <= 1:
-            n, d = numerator * cast(int, 10 ** (1 - exponent)), denominator
+        if exponent <= 0:
+            n, d = numerator * cast(int, 10**-exponent), denominator
         else:
-            n, d = numerator, denominator * cast(int, 10 ** (exponent - 1))
+            n, d = numerator, denominator * cast(int, 10**exponent)
 
         # Round-for-reround
-        tenths, inexact = divmod(n, d)
-        if tenths % 5 == 0 and inexact:
-            tenths += 1
-
+        significand, inexact = divmod(n, d)
         return IntermediateForm(
             sign=sign,
-            significand=tenths,
-            exponent=exponent - 1,
+            significand=significand + (inexact and significand % 5 == 0),
+            exponent=exponent,
         )
 
     def to_zero(self) -> "IntermediateForm":
         """
-        Round towards zero to the nearest value with quarters = 0.
+        Drop the least significant digit, rounding towards zero.
         """
-        return IntermediateForm(
-            sign=self.sign,
-            significand=self.significand // 10,
-            exponent=self.exponent + 1,
+        return replace(
+            self, significand=self.significand // 10, exponent=self.exponent + 1
         )
 
     def to_away(self) -> "IntermediateForm":
         """
-        Round away from zero to the nearest value with quarters = 0.
+        Drop the least significant digit, rounding away from zero.
         """
-        return IntermediateForm(
-            sign=self.sign,
-            significand=-(-self.significand // 10),
-            exponent=self.exponent + 1,
-        )
-
-    def as_int(self) -> int:
-        """
-        Interpret as int, provided that the exponent is zero.
-        """
-        if self.exponent:
-            raise ValueError("Not an exact integer")
-        return -self.significand if self.sign else self.significand
-
-    def nudge(self) -> "IntermediateForm":
-        """
-        Increment the exponent and divide the significand by 10.
-
-        Expected to be used only when the signficand is divisible by 10.
-        """
-        new_significand, remainder = divmod(self.significand, 10)
-        if remainder:
-            raise ValueError("significand not divisible by 10")
-        return IntermediateForm(
-            sign=self.sign,
-            significand=new_significand,
-            exponent=self.exponent + 1,
+        return replace(
+            self, significand=-(-self.significand // 10), exponent=self.exponent + 1
         )

--- a/src/rounder/intermediate.py
+++ b/src/rounder/intermediate.py
@@ -11,25 +11,20 @@ class IntermediateForm:
     """
     Intermediate value for rounding and formatting operations.
 
-    An IntermediateForm represents a value of the form significand * 10**exponent,
-    where significand is a quarter integer (i.e., 4*significand is an integer).
-    Signed zeros are supported.
+    This is essentially a more accessible version of the Decimal type, that only
+    supports finite Decimal instances.
 
-    The value represented is (significand + quarters/4) * 10**exponent if sign is False,
-    and the negation of that if sign is True.
+    The value represented is (-1)**sign * significand * 10**exponent.
     """
 
     # True for negative, False for positive.
     sign: bool
 
-    # Nonnegative integer giving the integral part of the significand.
+    # Significand
     significand: int
 
-    # Integer giving the decimal exponent.
+    # Exponent
     exponent: int
-
-    # Integer in range(4) giving the number of quarters in the significand.
-    quarters: int = 0
 
     @classmethod
     def from_signed_fraction(
@@ -38,48 +33,47 @@ class IntermediateForm:
         """
         Create from a quotient of the form ±(n/d).
         """
-        if exponent <= 0:
-            n, d = numerator * cast(int, 10**-exponent), denominator
+        if exponent <= 1:
+            n, d = numerator * cast(int, 10 ** (1 - exponent)), denominator
         else:
-            n, d = numerator, denominator * cast(int, 10**exponent)
+            n, d = numerator, denominator * cast(int, 10 ** (exponent - 1))
 
-        quarters, inexact = divmod(4 * n, d)
-        whole, part = divmod(quarters | bool(inexact), 4)
+        # Round-for-reround
+        tenths, inexact = divmod(n, d)
+        if tenths % 5 == 0 and inexact:
+            tenths += 1
+
         return IntermediateForm(
-            sign=sign, significand=whole, quarters=part, exponent=exponent
+            sign=sign,
+            significand=tenths,
+            exponent=exponent - 1,
         )
 
     def to_zero(self) -> "IntermediateForm":
         """
         Round towards zero to the nearest value with quarters = 0.
         """
-        if not self.quarters:
-            return self
-
         return IntermediateForm(
             sign=self.sign,
-            significand=self.significand,
-            exponent=self.exponent,
+            significand=self.significand // 10,
+            exponent=self.exponent + 1,
         )
 
     def to_away(self) -> "IntermediateForm":
         """
         Round away from zero to the nearest value with quarters = 0.
         """
-        if not self.quarters:
-            return self
-
         return IntermediateForm(
             sign=self.sign,
-            significand=self.significand + 1,
-            exponent=self.exponent,
+            significand=-(-self.significand // 10),
+            exponent=self.exponent + 1,
         )
 
     def as_int(self) -> int:
         """
         Interpret as int, provided that the exponent is zero.
         """
-        if self.exponent or self.quarters:
+        if self.exponent:
             raise ValueError("Not an exact integer")
         return -self.significand if self.sign else self.significand
 
@@ -89,11 +83,11 @@ class IntermediateForm:
 
         Expected to be used only when the signficand is divisible by 10.
         """
-        significand, remainder = divmod(self.significand, 10)
-        if remainder or self.quarters:
+        new_significand, remainder = divmod(self.significand, 10)
+        if remainder:
             raise ValueError("significand not divisible by 10")
         return IntermediateForm(
             sign=self.sign,
-            significand=significand,
+            significand=new_significand,
             exponent=self.exponent + 1,
         )

--- a/src/rounder/modes.py
+++ b/src/rounder/modes.py
@@ -65,7 +65,7 @@ from rounder.intermediate import IntermediateForm
 
 class RoundingMode(abc.ABC):
     @abc.abstractmethod
-    def round(self, quarters: IntermediateForm) -> IntermediateForm:
+    def round(self, intermediate: IntermediateForm, /) -> IntermediateForm:
         """
         Round using the given rounding mode.
         """

--- a/src/rounder/modes.py
+++ b/src/rounder/modes.py
@@ -65,7 +65,7 @@ from rounder.intermediate import IntermediateForm
 
 class RoundingMode(abc.ABC):
     @abc.abstractmethod
-    def round(self, intermediate: IntermediateForm, /) -> IntermediateForm:
+    def round(self, intermediate: IntermediateForm) -> IntermediateForm:
         """
         Round using the given rounding mode.
         """
@@ -76,7 +76,7 @@ class _StandardRoundingMode(RoundingMode):
     def __init__(self, signature: Tuple[Tuple[int, int], Tuple[int, int]]):
         self._signature = signature
 
-    def round(self, intermediate: IntermediateForm, /) -> IntermediateForm:
+    def round(self, intermediate: IntermediateForm) -> IntermediateForm:
         """
         Round using the given rounding mode.
         """
@@ -86,7 +86,7 @@ class _StandardRoundingMode(RoundingMode):
 
 
 class _RoundForReroundRoundingMode(RoundingMode):
-    def round(self, intermediate: IntermediateForm, /) -> IntermediateForm:
+    def round(self, intermediate: IntermediateForm) -> IntermediateForm:
         """
         Round using the given rounding mode.
         """

--- a/src/rounder/modes.py
+++ b/src/rounder/modes.py
@@ -76,38 +76,39 @@ class _StandardRoundingMode(RoundingMode):
     def __init__(self, signature: Tuple[Tuple[int, int], Tuple[int, int]]):
         self._signature = signature
 
-    def round(self, quarters: IntermediateForm) -> IntermediateForm:
+    def round(self, intermediate: IntermediateForm, /) -> IntermediateForm:
         """
         Round using the given rounding mode.
         """
-        is_odd = quarters.significand & 1
-        round_up = quarters.quarters + self._signature[quarters.sign][is_odd] >= 4
-        return quarters.to_away() if round_up else quarters.to_zero()
+        is_odd, tenths = divmod(intermediate.significand % 20, 10)
+        round_up = tenths + self._signature[intermediate.sign][is_odd] >= 10
+        return intermediate.to_away() if round_up else intermediate.to_zero()
 
 
 class _RoundForReroundRoundingMode(RoundingMode):
-    def round(self, quarters: IntermediateForm) -> IntermediateForm:
+    def round(self, intermediate: IntermediateForm, /) -> IntermediateForm:
         """
         Round using the given rounding mode.
         """
-        return quarters.to_zero() if quarters.significand % 5 else quarters.to_away()
+        round_up = intermediate.significand % 50 < 10
+        return intermediate.to_away() if round_up else intermediate.to_zero()
 
 
 #: Round for re-round.
 TO_ZERO_05_AWAY = _RoundForReroundRoundingMode()
 
 #: To-nearest rounding modes.
-TIES_TO_ZERO: RoundingMode = _StandardRoundingMode(((1, 1), (1, 1)))
-TIES_TO_AWAY: RoundingMode = _StandardRoundingMode(((2, 2), (2, 2)))
-TIES_TO_MINUS: RoundingMode = _StandardRoundingMode(((1, 1), (2, 2)))
-TIES_TO_PLUS: RoundingMode = _StandardRoundingMode(((2, 2), (1, 1)))
-TIES_TO_EVEN: RoundingMode = _StandardRoundingMode(((1, 2), (1, 2)))
-TIES_TO_ODD: RoundingMode = _StandardRoundingMode(((2, 1), (2, 1)))
+TIES_TO_ZERO: RoundingMode = _StandardRoundingMode(((4, 4), (4, 4)))
+TIES_TO_AWAY: RoundingMode = _StandardRoundingMode(((5, 5), (5, 5)))
+TIES_TO_MINUS: RoundingMode = _StandardRoundingMode(((4, 4), (5, 5)))
+TIES_TO_PLUS: RoundingMode = _StandardRoundingMode(((5, 5), (4, 4)))
+TIES_TO_EVEN: RoundingMode = _StandardRoundingMode(((4, 5), (4, 5)))
+TIES_TO_ODD: RoundingMode = _StandardRoundingMode(((5, 4), (5, 4)))
 
 #: Directed rounding modes.
 TO_ZERO: RoundingMode = _StandardRoundingMode(((0, 0), (0, 0)))
-TO_AWAY: RoundingMode = _StandardRoundingMode(((3, 3), (3, 3)))
-TO_MINUS: RoundingMode = _StandardRoundingMode(((0, 0), (3, 3)))
-TO_PLUS: RoundingMode = _StandardRoundingMode(((3, 3), (0, 0)))
-TO_EVEN: RoundingMode = _StandardRoundingMode(((0, 3), (0, 3)))
-TO_ODD: RoundingMode = _StandardRoundingMode(((3, 0), (3, 0)))
+TO_AWAY: RoundingMode = _StandardRoundingMode(((9, 9), (9, 9)))
+TO_MINUS: RoundingMode = _StandardRoundingMode(((0, 0), (9, 9)))
+TO_PLUS: RoundingMode = _StandardRoundingMode(((9, 9), (0, 0)))
+TO_EVEN: RoundingMode = _StandardRoundingMode(((0, 9), (0, 9)))
+TO_ODD: RoundingMode = _StandardRoundingMode(((9, 0), (9, 0)))


### PR DESCRIPTION
This PR does more internal refactoring and cleanup. The primary change is that intermediate values are now represented with an extra decimal digit rather than a `quarters` field. This is likely a bit less efficient, but it simplifies the conceptual model substantially.