### PR TITLE
Add aliases for floor, ceil and trunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Or if you want a version of `math.ceil` that accepts a number of places after th
 you can do:
 
 ```python
->>> from rounder import round_to_plus as ceil
+>>> from rounder import ceil
 >>> ceil(1.78)
 2
 >>> ceil(1.782, 2)
@@ -93,10 +93,11 @@ you can do:
 
 The complete list of functions is [below](#rounding-modes)
 
-## Rounding modes
+## Rounding modes and mode-specific rounding function
 
 These are the currently supported rounding modes, along with their corresponding
-mode-specific rounding functions.
+mode-specific rounding functions. The functions `trunc`, `floor` and `ceil` are
+aliases for `round_to_zero`, `round_to_minus` and `round_to_plus`, respectively.
 
 ### To-nearest rounding modes
 

--- a/src/rounder/__init__.py
+++ b/src/rounder/__init__.py
@@ -38,6 +38,10 @@ from rounder.modes import (
 )
 from rounder.round_to import round, round_to_figures, round_to_int, round_to_places
 
+ceil = round_to_plus
+floor = round_to_minus
+trunc = round_to_zero
+
 __all__ = [
     # Top-level rounding functions
     "round",
@@ -58,6 +62,10 @@ __all__ = [
     "round_to_plus",
     "round_to_zero",
     "round_to_zero_05_away",
+    # Aliases
+    "ceil",
+    "floor",
+    "trunc",
     # Rounding modes - to-nearest
     "TIES_TO_AWAY",
     "TIES_TO_EVEN",

--- a/src/rounder/test/test_round.py
+++ b/src/rounder/test/test_round.py
@@ -21,6 +21,8 @@ from rounder import (
     TO_ODD,
     TO_PLUS,
     TO_ZERO,
+    ceil,
+    floor,
     round,
     round_ties_to_away,
     round_ties_to_even,
@@ -37,6 +39,7 @@ from rounder import (
     round_to_plus,
     round_to_zero,
     round_to_zero_05_away,
+    trunc,
 )
 
 #: A selection of IEEE 754 binary64 floating-point values used in a wide
@@ -930,6 +933,11 @@ class TestRound(unittest.TestCase):
         # ... but only by keyword
         with self.assertRaises(TypeError):
             round(3.5, None, TIES_TO_ODD)  # type: ignore
+
+    def test_aliases(self) -> None:
+        self.assertIs(ceil, round_to_plus)
+        self.assertIs(floor, round_to_minus)
+        self.assertIs(trunc, round_to_zero)
 
     def assertIntsIdentical(self, first: int, second: int) -> None:
         self.assertEqual(type(first), int)


### PR DESCRIPTION
This PR adds convenience aliases for `floor`, `ceil` and `trunc`.

```python
>>> from rounder import ceil, floor, trunc
>>> ceil(2.342, 2)
2.35
>>> ceil(-2.342, 2)
-2.34
>>> floor(2.345, 2)
2.34
>>> floor(-2.345, 2)
-2.35
>>> trunc(2.347, 2)
2.34
>>> trunc(-2.347, 2)
-2.34
```

